### PR TITLE
Execution handler upgrade to PowerShell3

### DIFF
--- a/UpdateAssemblyInfoTask/task.json
+++ b/UpdateAssemblyInfoTask/task.json
@@ -110,7 +110,7 @@
                    }
                ],
     "execution":  {
-                      "PowerShell":  {
+                      "PowerShell3":  {
                                          "target":  "$(currentDirectory)\\UpdateAssemblyInfo.ps1",
                                          "argumentFormat":  "",
                                          "workingDirectory":  ""


### PR DESCRIPTION
Fix for issue #14 .
Simply upgrade execution handler to PowerShell3.
Hope this will fix the warning.
How can I test the changes?